### PR TITLE
🛫更改部署方式

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,19 @@ on:
 jobs:
   build:
 
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - run: gitbook install
-    - run: gitbook build
+    #- uses: actions/setup-node@v2
+    #  with:
+    #    node-version: '10.15'
+    #- run: npm install gitbook-cli -g
+    #- run: gitbook fetch 3.2.3
+    #- run: gitbook install
+    #- run: gitbook build . public
+    - name: Gitbook Action           # https://github.com/ZanderZhao/gitbook-action/releases
+      uses: ZanderZhao/gitbook-action@v1.2.4  # -> or ZanderZhao/gitbook-action@master.  If not use master click above, use latest please 
+      with:                                   #    or fork this repo and use YourName/gitbook-action@master
+        token: ${{ secrets.PERSONAL }}
+        source_branch: main

--- a/book.json
+++ b/book.json
@@ -1,0 +1,3 @@
+{
+    "plugins": ["hints"]
+}

--- a/book.json
+++ b/book.json
@@ -1,3 +1,3 @@
 {
-    "plugins": ["hints"]
+    "plugins": ["hints","callouts","intopic-toc"]
 }


### PR DESCRIPTION
* 增加book.json，提供插件依赖
* 改为在Github Pages上进行部署，取消在自建服务器的部署

设置方式：
1. 在账户设置 - Developer settings - Personal access tokens中选择Generate new token，勾选`repo`权限
2. 在仓库设置 - Secrets - Actions中选择New repository secret，将上一步生成的token粘贴进去，并命名为`PERSONAL`
3. 将此Pull Request合并，待Actions全部执行完毕后，在仓库设置 - Pages - Source中选择`gh-pages`，`/(root)`